### PR TITLE
Remove trailing comma from SQL table definition

### DIFF
--- a/app.py
+++ b/app.py
@@ -1270,7 +1270,7 @@ def init_db():
                   work_date TEXT NOT NULL,
                   status TEXT DEFAULT 'draft',
                   created_at TEXT,
-                  submitted_at TEXT,
+                  submitted_at TEXT
                   )''')
 
     # Community Maintenance Line Items table - stores equipment data


### PR DESCRIPTION
## Summary
Fixed a SQL syntax error in the database initialization code by removing a trailing comma from the `submissions` table definition.

## Key Changes
- Removed trailing comma after the `submitted_at TEXT` column in the `submissions` table schema
- This fixes invalid SQL syntax that would have caused database initialization to fail

## Details
The trailing comma after the last column definition in a CREATE TABLE statement is invalid SQL syntax. This change ensures the database schema can be properly initialized without syntax errors.

https://claude.ai/code/session_01ErQd5VLYZrMrmPczXd723N