### PR TITLE
Fix: add null guards to toggleClockSection and toggleCommunityClocksS…

### DIFF
--- a/app.py
+++ b/app.py
@@ -16091,6 +16091,7 @@ COMMUNITY_BILLING_OFFICE_TEMPLATE = '''
             event.preventDefault();
             const list = document.getElementById(`comm-clocks-list-${communityId}`);
             const arrow = document.getElementById(`comm-clock-arrow-${communityId}`);
+            if (!list || !arrow) return;
             list.classList.toggle('visible');
             arrow.classList.toggle('expanded');
 
@@ -16455,6 +16456,7 @@ COMMUNITY_BILLING_OFFICE_TEMPLATE = '''
             event.preventDefault();
             const list = document.getElementById(`houses-list-${communityId}`);
             const arrow = document.getElementById(`arrow-${communityId}`);
+            if (!list || !arrow) return;
 
             list.classList.toggle('visible');
             arrow.classList.toggle('expanded');


### PR DESCRIPTION
…ection

toggleClockSection (used by the Verona Walk HOA Clock Addresses dropdown) had no null guard — if getElementById returned null for any reason, the call to .classList.toggle() threw a TypeError and the section silently refused to expand.  Adds the same defensive guard that was applied to toggleClockAddresses in the previous fix.

toggleCommunityClocksSection also lacked a guard and referenced elements (comm-clocks-list-*) that are never rendered, so it would always crash if ever called.  Guard added for consistency and safety.

https://claude.ai/code/session_01GRmgr9TXH7yUGyJ3NKpAYs