### PR TITLE
Fix potential SyntaxError: convert block-level function to const arro…

### DIFF
--- a/app.py
+++ b/app.py
@@ -16454,8 +16454,18 @@ COMMUNITY_BILLING_OFFICE_TEMPLATE = '''
         // Verona Walk HOA clock management functions
         function toggleClockSection(event, communityId) {
             event.preventDefault();
-            const list = document.getElementById(`houses-list-${communityId}`);
-            const arrow = document.getElementById(`arrow-${communityId}`);
+            let list = document.getElementById(`houses-list-${communityId}`);
+            let arrow = document.getElementById(`arrow-${communityId}`);
+
+            // Fallback to DOM traversal if IDs don't resolve
+            if (!list || !arrow) {
+                const header = event.target.closest('.houses-header');
+                if (!header) return;
+                const section = header.closest('.houses-section');
+                if (!section) return;
+                list = list || section.querySelector('.houses-list');
+                arrow = arrow || header.querySelector('.expand-arrow');
+            }
             if (!list || !arrow) return;
 
             list.classList.toggle('visible');
@@ -16518,7 +16528,7 @@ COMMUNITY_BILLING_OFFICE_TEMPLATE = '''
                     const regularAddresses = clock.addresses.filter(a => !a.is_common_area);
                     const commonAreaAddresses = clock.common_area_addresses || [];
 
-                    function renderAddressList(addrs, listId) {
+                    const renderAddressList = (addrs, listId) => {
                         if (addrs.length === 0) return '';
                         const isCA = listId.startsWith('ca-');
                         const moveLabel = isCA ? 'Move to Addresses' : 'Move to Common Area';
@@ -17480,6 +17490,7 @@ COMMUNITY_BILLING_OFFICE_TEMPLATE = '''
             event.preventDefault();
             const list = document.getElementById(`houses-list-${communityId}`);
             const arrow = document.getElementById(`arrow-${communityId}`);
+            if (!list || !arrow) return;
 
             list.classList.toggle('visible');
             arrow.classList.toggle('expanded');


### PR DESCRIPTION
…w fn, add DOM traversal fallback to toggleClockSection, add null guard to toggleHousesSection

- Convert renderAddressList from block-level function declaration inside forEach to const arrow function expression — block-level function declarations inside arrow callbacks have subtle browser behavior variations that can cause SyntaxError in some environments
- Enhance toggleClockSection with DOM traversal fallback: if getElementById can't find the list/arrow by ID, walk up the DOM from the clicked element using closest() to locate them — makes the toggle robust against any ID mismatch
- Add null guard to toggleHousesSection (dead code path) to prevent TypeError if either element is missing

https://claude.ai/code/session_01GRmgr9TXH7yUGyJ3NKpAYs