### PR TITLE
Collapse clock sections by default on initial load

### DIFF
--- a/app.py
+++ b/app.py
@@ -16145,8 +16145,8 @@ COMMUNITY_BILLING_OFFICE_TEMPLATE = '''
                 // Merge into one flat list — no common area separation
                 const allAddresses = [...regularAddresses, ...commonAreaAddresses];
                 const totalCount = allAddresses.length;
-                // Open if it was already open, or if it has no addresses yet
-                const isOpen = openClocks.includes(clock.clock_number) || totalCount === 0;
+                // Only open if it was already open before re-render
+                const isOpen = openClocks.includes(clock.clock_number);
 
                 // Use the same clock-container / clock-header / clock-addresses CSS as Verona Walk
                 html += `


### PR DESCRIPTION
Remove the auto-expand logic that opened clocks with no addresses. Now all clock sections start collapsed and only re-open if they were already open before a re-render (preserving user state on reload).

https://claude.ai/code/session_01GRmgr9TXH7yUGyJ3NKpAYs