### PR TITLE
Fix station cell access and null handling in clock parsing

### DIFF
--- a/app.py
+++ b/app.py
@@ -20880,7 +20880,8 @@ def community_clock_import_excel():
                 if zone_num is None:
                     continue  # skip non-integer rows (headers, totals, notes)
 
-                station = str(station_cell).strip()
+                station_cell = row[station_col].value if len(row) > station_col else None
+                station = str(station_cell).strip() if station_cell is not None else ''
                 if not station or station.lower() in SKIP_VALUES:
                     continue
 


### PR DESCRIPTION
## Summary
Improved robustness of station cell extraction and null value handling in the clock number parsing logic to prevent potential index out of bounds errors and attribute errors.

## Key Changes
- Added bounds checking before accessing `station_col` index in the row to prevent IndexError when row length is insufficient
- Refactored station cell extraction to explicitly retrieve the cell value using `.value` attribute
- Added null check before calling `.strip()` on station cell to prevent AttributeError when cell is None
- Maintains existing behavior of skipping empty or invalid station values

## Implementation Details
The change replaces a direct string conversion of the station cell with a safer two-step approach:
1. First, safely extract the cell value with bounds checking: `row[station_col].value if len(row) > station_col else None`
2. Then, conditionally strip whitespace only if the cell is not None: `str(station_cell).strip() if station_cell is not None else ''`

This prevents crashes when processing malformed or incomplete row data while preserving the original filtering logic for empty or skipped station values.

https://claude.ai/code/session_01ETRDfvhNSUWha3La6uaC9f