### PR TITLE
Fix translation not applying on page load in community billing tech page

### DIFF
--- a/app.py
+++ b/app.py
@@ -14272,9 +14272,7 @@ COMMUNITY_BILLING_TECH_TEMPLATE = '''
             applyLanguage(currentLang);
         }
 
-        document.addEventListener('DOMContentLoaded', function() {
-            applyLanguage(currentLang);
-        });
+        applyLanguage(currentLang);
 
         function t(key, vars) {
             const str = (TRANSLATIONS[currentLang] || TRANSLATIONS.en)[key] || key;


### PR DESCRIPTION
applyLanguage() was registered inside DOMContentLoaded, but since the script is at the end of <body> all DOM elements are already available — calling it directly is more reliable and ensures Spanish renders immediately on page load when the preference is stored in localStorage.

https://claude.ai/code/session_01KfW53uCJGjtWyheavFmDnY