### PR TITLE
Fix zone input: preserve zone number when line already starts with "Z…

### DIFF
--- a/app.py
+++ b/app.py
@@ -17091,13 +17091,19 @@ COMMUNITY_BILLING_OFFICE_TEMPLATE = '''
         }
 
         // Format address lines as "ZONE N - description" to match Verona Walk style.
-        // Lines that already begin with "N -" or "N–" are normalised (ZONE prepended).
-        // Lines that already begin with "ZONE N -" are left unchanged.
+        // Lines that already begin with "ZONE N -" are normalised (uppercase, dash).
+        // Lines that begin with "ZONE N" (no dash) have their zone number preserved.
+        // Lines that begin with "N -" or "N–" are normalised (ZONE prepended).
         // All other lines get an auto-assigned zone number starting from startZone.
         function applyZoneFormat(lines, startZone) {
             let auto = startZone;
             return lines.map(line => {
-                if (/^ZONE\s+\d+\s*[-–]/i.test(line)) return line;   // already formatted
+                const zoneMatch = line.match(/^ZONE\s+(\d+)\s*([\s\S]*)/i);
+                if (zoneMatch) {
+                    const num = zoneMatch[1];
+                    const rest = zoneMatch[2].replace(/^[-–]\s*/, '').trim();
+                    return rest ? `ZONE ${num} - ${rest}` : `ZONE ${num}`;
+                }
                 const m = line.match(/^(\d+)\s*[-–]\s*([\s\S]+)/);
                 if (m) return `ZONE ${m[1]} - ${m[2].trim()}`;             // has leading number
                 return `ZONE ${auto++} - ${line}`;                         // plain description


### PR DESCRIPTION
…one N"

When adding addresses to the community maintenance center, if a line starts with "Zone N" (with or without a dash), extract and reuse that zone number instead of auto-assigning a new one.

https://claude.ai/code/session_01Hma15k5AJhsbqMA1W4Q7bQ