### PR TITLE
Fix zone parsing to handle "Zone #N" format (hash before number)

### DIFF
--- a/app.py
+++ b/app.py
@@ -17098,7 +17098,7 @@ COMMUNITY_BILLING_OFFICE_TEMPLATE = '''
         function applyZoneFormat(lines, startZone) {
             let auto = startZone;
             return lines.map(line => {
-                const zoneMatch = line.match(/^ZONE\s+(\d+)\s*([\s\S]*)/i);
+                const zoneMatch = line.match(/^ZONE\s*#?\s*(\d+)\s*([\s\S]*)/i);
                 if (zoneMatch) {
                     const num = zoneMatch[1];
                     const rest = zoneMatch[2].replace(/^[-–]\s*/, '').trim();


### PR DESCRIPTION
Input like "Zone #3 - description" was not matching the zone regex due to the # symbol, causing it to fall through to auto-numbering. Now "Zone #3" correctly resolves to "ZONE 3".

https://claude.ai/code/session_01Hma15k5AJhsbqMA1W4Q7bQ