### PR TITLE
Fix zone parsing to handle leading dash before Zone (e.g. "- Zone#3-")

### DIFF
--- a/app.py
+++ b/app.py
@@ -17098,7 +17098,9 @@ COMMUNITY_BILLING_OFFICE_TEMPLATE = '''
         function applyZoneFormat(lines, startZone) {
             let auto = startZone;
             return lines.map(line => {
-                const zoneMatch = line.match(/^ZONE\s*#?\s*(\d+)\s*([\s\S]*)/i);
+                // Strip leading dash/hyphen + whitespace (e.g. "- Zone#3-" → "Zone#3-")
+                const stripped = line.replace(/^[-–]\s*/, '');
+                const zoneMatch = stripped.match(/^ZONE\s*#?\s*(\d+)\s*([\s\S]*)/i);
                 if (zoneMatch) {
                     const num = zoneMatch[1];
                     const rest = zoneMatch[2].replace(/^[-–]\s*/, '').trim();


### PR DESCRIPTION
Pasted lines starting with "- Zone#N-" were not matching the zone regex because of the leading dash, causing them to be auto-numbered. Now the leading dash is stripped before zone detection so "- Zone#3- D#..." correctly becomes "ZONE 3 - D#...".

https://claude.ai/code/session_01Hma15k5AJhsbqMA1W4Q7bQ