### PR TITLE
Fix zone number duplication when pasting tab-separated data from Excel

### DIFF
--- a/app.py
+++ b/app.py
@@ -19459,6 +19459,25 @@ COMMUNITY_BILLING_OFFICE_TEMPLATE = '''
         function applyZoneFormat(lines, startZone) {
             let auto = startZone;
             return lines.map(line => {
+                // When pasting from Excel/Sheets the line arrives tab-separated.
+                // Treat first column as zone identifier, remaining columns as the address.
+                if (line.includes('\t')) {
+                    const parts = line.split('\t');
+                    const firstCol = parts[0].trim();
+                    const rest = parts.slice(1).map(p => p.trim()).filter(Boolean).join(' ');
+                    const zoneNumMatch = firstCol.match(/^ZONE\s*#?\s*(\d+)$/i);
+                    const numOnlyMatch = firstCol.match(/^(\d+)$/);
+                    if (zoneNumMatch) {
+                        return rest ? `ZONE ${zoneNumMatch[1]} - ${rest}` : `ZONE ${zoneNumMatch[1]}`;
+                    }
+                    if (numOnlyMatch) {
+                        return rest ? `ZONE ${numOnlyMatch[1]} - ${rest}` : `ZONE ${numOnlyMatch[1]}`;
+                    }
+                    // First column isn't a zone number — treat whole row as description
+                    const combined = [firstCol, rest].filter(Boolean).join(' ');
+                    return `ZONE ${auto++} - ${combined}`;
+                }
+
                 // Strip leading dash/hyphen + whitespace (e.g. "- Zone#3-" → "Zone#3-")
                 const stripped = line.replace(/^[-–]\s*/, '');
                 const zoneMatch = stripped.match(/^ZONE\s*#?\s*(\d+)\s*([\s\S]*)/i);


### PR DESCRIPTION
When copying from a spreadsheet with two columns (zone#, address), each pasted line arrives as "1\t12266". applyZoneFormat didn't handle tabs so the whole line became the address text, producing "ZONE 1 - 1 12266".

Now lines with tabs are split on the first tab: if the left column is a plain number or "ZONE N", it becomes the zone number and the right side becomes the address — giving the correct "ZONE 1 - 12266" result. Applies to both clock-address and custom-tab bulk imports.

https://claude.ai/code/session_016mkLf8xFCfaTGqpP67TvLB