### PR TITLE
Fix SyntaxError: escape regex \r\n in Python template string

### DIFF
--- a/app.py
+++ b/app.py
@@ -16959,7 +16959,7 @@ COMMUNITY_BILLING_SPREADSHEET_TEMPLATE = '''
                         if (!clipText) return;
 
                         // Parse TSV rows (Excel copies as tab-separated, newline-delimited)
-                        var pasteRows = clipText.split(/\r?\n/);
+                        var pasteRows = clipText.split(/\\r?\\n/);
                         // Drop trailing empty row Excel often appends
                         while (pasteRows.length && pasteRows[pasteRows.length - 1].trim() === '') {
                             pasteRows.pop();


### PR DESCRIPTION
The JS regex /\r?\n/ inside the Python triple-quoted template string was being interpreted by Python as literal CR+LF control characters. The browser then saw an unterminated regex literal and threw:
  SyntaxError: Invalid regular expression: missing /

This prevented the entire first <script> block from executing, so vwSelectClock was never defined. Selecting any clock on the Verona Walk HOA community billing form (and any other clock-based community) produced:
  ReferenceError: vwSelectClock is not defined

and no addresses were shown. Fix by double-escaping the backslashes so Python passes \r?\n through to JS literally.

https://claude.ai/code/session_01D3Mnirj43k3oX125DGjKnf