### PR TITLE
Fix JS SyntaxError: double-escape \n in confirm() string

### DIFF
--- a/app.py
+++ b/app.py
@@ -21146,7 +21146,7 @@ COMMUNITY_BILLING_OFFICE_TEMPLATE = '''
         }
 
         function applyDefaultPricing(communityId) {
-            if (!confirm('Link this community to Default Pricing?\n\nThis copies the current default values and marks the community as synced - future changes to Default Pricing will automatically update it.')) return;
+            if (!confirm('Link this community to Default Pricing?\\n\\nThis copies the current default values and marks the community as synced - future changes to Default Pricing will automatically update it.')) return;
             fetch('/community_apply_default_pricing', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},


### PR DESCRIPTION
Python processes \n in triple-quoted strings as actual newlines (0x0a), which breaks the JS single-quoted string literal at runtime. Use \\n so Python stores a literal backslash-n that JavaScript then interprets as a newline escape sequence in the confirm dialog.

https://claude.ai/code/session_01N3z2Rxc5cs35d2Wwx3gZcG