### PR TITLE
Remove duplicate CSRF token input field

### DIFF
--- a/app.py
+++ b/app.py
@@ -8729,7 +8729,6 @@ LOGIN_TEMPLATE = '''
         {% endwith %}
         <form method="POST">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <div class="fg">
                 <label data-i18n="username_label">Username</label>
                 <input type="text" name="username" required autofocus autocomplete="username" placeholder="Enter your username">


### PR DESCRIPTION
## Summary
Removed a duplicate CSRF token hidden input field from the form template.

## Key Changes
- Removed one of two identical `<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">` lines that were present consecutively in the form

## Details
The form had a duplicate CSRF token input field on consecutive lines. This change removes the redundant line, keeping only a single CSRF token input which is sufficient for form security and prevents any potential issues with duplicate token handling.

https://claude.ai/code/session_01GuaEEdt4bPHnhPKrAAvcb6