### PR TITLE
Work Orders: issue marker is just the ✕ (no label), home pin locked, no tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -36454,7 +36454,6 @@ function setIssue(lat,lng){
   else {
     var ico=L.divIcon({className:'', html:'<div class="issue-ico">✕</div>', iconSize:[30,30], iconAnchor:[15,15]});
     issueMarker=L.marker([lat,lng],{icon:ico, draggable:true, zIndexOffset:1200}).addTo(pmap);
-    issueMarker.bindTooltip('Problem here', {permanent:true, direction:'top', offset:[0,-14], className:'issue-tip'}).openTooltip();
     issueMarker.on('dragend',function(){ var ll=issueMarker.getLatLng();
       document.getElementById('p-lat').value=ll.lat; document.getElementById('p-lng').value=ll.lng; });
   }


### PR DESCRIPTION
Small follow-ups:

- The issue marker now shows **just the red ✕** — removed its text tooltip.
- The **"This is your home"** pin keeps its label and remains **non-movable** (fixed, non-interactive).
- Confirmed there is **no location tracking / current-location** anywhere — the home is located solely by geocoding the **entered address**.

https://claude.ai/code/session_012kpyHXLrF8j9jgwVxuZtEE

---
_Generated by [Claude Code](https://claude.ai/code/session_012kpyHXLrF8j9jgwVxuZtEE)_